### PR TITLE
Refactor to simplify logic, avoid retain cycle & repeated state delegate calls #2

### DIFF
--- a/Example/Source/Controller/RefreshViewController.swift
+++ b/Example/Source/Controller/RefreshViewController.swift
@@ -45,9 +45,9 @@ class RefreshViewController: UITableViewController {
         // Set up pull to refresh
         setUpPullToRefresh()
 
-        tableView.addLoadMore(action: { [weak self] in
+        tableView.addLoadMore { [weak self] in
             self?.handleLoadMore()
-        })
+        }
     }
     
     override func numberOfSections(in tableView: UITableView) -> Int {
@@ -78,15 +78,14 @@ extension RefreshViewController {
         switch headerStyle {
         case .custom:
             let animator = TextLoadingAnimator()
-            tableView.addPullToRefresh(withAnimator: animator, height: 60) { [weak self] in
+            tableView.addPullToRefresh(height: 60, contentView: animator) { [weak self] in
                 self?.handleRefresh()
             }
 
         case .default:
-            tableView.addPullToRefresh(action: { [weak self] in
+            tableView.addPullToRefresh() { [weak self] in
                 self?.handleRefresh()
-            })
-
+            }
         }
     }
 

--- a/Example/Source/View/TextLoadingAnimator.swift
+++ b/Example/Source/View/TextLoadingAnimator.swift
@@ -52,16 +52,18 @@ class TextLoadingAnimator: UIView, PullToRefreshDelegate {
             spinner.isHidden = true
             titleLabel.isHidden = true
         case .pulling:
+            spinner.stopAnimating()
             spinner.isHidden = false
             titleLabel.isHidden = false
             titleLabel.text = "Pulling"
         case .releaseToLoad:
+            spinner.stopAnimating()
+            spinner.isHidden = false
             titleLabel.text = "Release to start refresh"
         case .loading:
             titleLabel.text = "Loading..."
+            spinner.isHidden = false
             spinner.startAnimating()
         }
-
-        self.setNeedsLayout()
     }
 }

--- a/Example/Source/View/TextLoadingAnimator.swift
+++ b/Example/Source/View/TextLoadingAnimator.swift
@@ -46,40 +46,22 @@ class TextLoadingAnimator: UIView, PullToRefreshDelegate {
     }
 
     func pullToRefresh(_ view: PullToRefreshView, stateDidChange state: PullToRefreshState) {
-        if state == .idle {
+        switch state {
+        case .idle:
+            spinner.stopAnimating()
             spinner.isHidden = true
             titleLabel.isHidden = true
-        } else if state == .pullToRefresh {
+        case .pulling:
             spinner.isHidden = false
             titleLabel.isHidden = false
-        }
-
-        // Update text for title lable
-        switch state {
-        case .pullToRefresh:
             titleLabel.text = "Pulling"
-        case .releaseToRefresh:
+        case .releaseToLoad:
             titleLabel.text = "Release to start refresh"
         case .loading:
             titleLabel.text = "Loading..."
-        default: break
+            spinner.startAnimating()
         }
 
         self.setNeedsLayout()
     }
-
-    func pullToRefreshAnimationDidStart(_ view: PullToRefreshView) {
-        spinner.isHidden = false
-        spinner.startAnimating()
-
-        titleLabel.isHidden = false
-    }
-
-    func pullToRefreshAnimationDidEnd(_ view: PullToRefreshView) {
-        spinner.isHidden = true
-        spinner.stopAnimating()
-
-        titleLabel.isHidden = true
-    }
-
 }

--- a/Source/LoadMore.swift
+++ b/Source/LoadMore.swift
@@ -15,7 +15,7 @@ public protocol LoadMoreDelegate {
 
 public class LoadMoreView: UIView {
 
-    // Default is true. When you set false load more view will be hide
+    // Default is true. When you set to false load more view will be hidden
     var isEnabled: Bool = true {
         didSet {
             if isEnabled {

--- a/Source/LoadMoreViewAnimator.swift
+++ b/Source/LoadMoreViewAnimator.swift
@@ -30,12 +30,12 @@ open class LoadMoreAnimator: UIView, LoadMoreDelegate {
         spinner.center = CGPoint(x: frame.size.width * 0.5, y: frame.size.height * 0.5)
     }
 
-    open func loadMoreAnimationDidStart(view: LoadMoreView) {
+    open func loadMoreDidStart(view: LoadMoreView) {
         spinner.isHidden = false
         spinner.startAnimating()
     }
 
-    open func loadMoreAnimationDidEnd(view: LoadMoreView) {
+    open func loadMoreDidEnd(view: LoadMoreView) {
         spinner.isHidden = true
         spinner.stopAnimating()
 

--- a/Source/PullToRefresh.swift
+++ b/Source/PullToRefresh.swift
@@ -128,8 +128,12 @@ extension PullToRefreshView {
 
         originalContentInsets = scrollView.contentInset
 
-        // If not in pulled down state, simply return
-        guard scrollView.contentOffset.y <= -adjustedContentInset.top else { return }
+        // If not in pulled down state, reset to idle state & return
+        guard scrollView.contentOffset.y <= -adjustedContentInset.top else {
+            isLoading = false
+            state = .idle
+            return
+        }
 
         // When scrollView's offset returns to the original content offset, change the state back to idle
         if scrollView.contentOffset.y == -adjustedContentInset.top {

--- a/Source/PullToRefresh.swift
+++ b/Source/PullToRefresh.swift
@@ -125,7 +125,6 @@ public class PullToRefreshView: UIView {
         var adjustedContentInset: UIEdgeInsets = .zero
         if #available(iOS 11.0, *) {
             adjustedContentInset = scrollView.adjustedContentInset
-            print("adjustedContentInset:\(adjustedContentInset)")
         }
 
         // If not in pulled down state, reset to idle & return

--- a/Source/PullToRefreshAnimator.swift
+++ b/Source/PullToRefreshAnimator.swift
@@ -31,7 +31,6 @@ open class PullToRefreshAnimator: UIView, PullToRefreshDelegate {
     }
 
     open func pullToRefresh(_ view: PullToRefreshView, stateDidChange state: PullToRefreshState) {
-        print("pullToRefresh state:\(state)")
         switch state {
         case .idle:
             spinner.stopAnimating()

--- a/Source/PullToRefreshAnimator.swift
+++ b/Source/PullToRefreshAnimator.swift
@@ -31,20 +31,25 @@ open class PullToRefreshAnimator: UIView, PullToRefreshDelegate {
     }
 
     open func pullToRefresh(_ view: PullToRefreshView, stateDidChange state: PullToRefreshState) {
+        switch state {
+        case .idle:
+            spinner.isHidden = true
+            spinner.stopAnimating()
+        case .pulling:
+            spinner.isHidden = false
+            spinner.stopAnimating()
+        case .releaseToLoad:
+            spinner.isHidden = false
+            spinner.stopAnimating()
+        case .loading:
+            spinner.isHidden = false
+            spinner.startAnimating()
+        }
+
         if state == .idle {
             spinner.isHidden = true
-        } else if state == .pullToRefresh {
+        } else if state == .pulling {
             spinner.isHidden = false
         }
-    }
-
-    open func pullToRefreshAnimationDidStart(_ view: PullToRefreshView) {
-        spinner.isHidden = false
-        spinner.startAnimating()
-    }
-
-    open func pullToRefreshAnimationDidEnd(_ view: PullToRefreshView) {
-        spinner.isHidden = true
-        spinner.stopAnimating()
     }
 }

--- a/Source/PullToRefreshAnimator.swift
+++ b/Source/PullToRefreshAnimator.swift
@@ -31,25 +31,20 @@ open class PullToRefreshAnimator: UIView, PullToRefreshDelegate {
     }
 
     open func pullToRefresh(_ view: PullToRefreshView, stateDidChange state: PullToRefreshState) {
+        print("pullToRefresh state:\(state)")
         switch state {
         case .idle:
+            spinner.stopAnimating()
             spinner.isHidden = true
-            spinner.stopAnimating()
         case .pulling:
-            spinner.isHidden = false
             spinner.stopAnimating()
+            spinner.isHidden = false
         case .releaseToLoad:
-            spinner.isHidden = false
             spinner.stopAnimating()
+            spinner.isHidden = false
         case .loading:
             spinner.isHidden = false
             spinner.startAnimating()
-        }
-
-        if state == .idle {
-            spinner.isHidden = true
-        } else if state == .pulling {
-            spinner.isHidden = false
         }
     }
 }

--- a/Source/UIScrollView+Extensions.swift
+++ b/Source/UIScrollView+Extensions.swift
@@ -37,18 +37,18 @@ public extension UIScrollView {
     }
 
     public func removePullToRefresh() {
+        pullToRefreshView?.removeFromSuperview()
         pullToRefreshView = nil
     }
 
     public func startPullToRefresh() {
-        pullToRefreshView?.isLoading = true
+        pullToRefreshView?.startLoading()
     }
 
     public func stopPullToRefresh() {
-        pullToRefreshView?.isLoading = false
+        pullToRefreshView?.stopLoading()
     }
 }
-
 
 /// Infinity Scrolling
 public extension UIScrollView {

--- a/Source/UIScrollView+Extensions.swift
+++ b/Source/UIScrollView+Extensions.swift
@@ -9,9 +9,7 @@
 import UIKit
 
 private var pullToRefreshKey: UInt8 = 0
-public let pullToRefreshDefaultHeight: CGFloat = 50
 private var loadMoreKey: UInt8 = 1
-public let loadMoreDefaultHeight: CGFloat = 50
 
 /// Pull To Refresh
 public extension UIScrollView {
@@ -26,31 +24,22 @@ public extension UIScrollView {
         }
     }
 
-    // Add pull to refresh view with default animator
-    public func addPullToRefresh(action: @escaping (() -> ())) {
-        let origin = CGPoint(x: 0, y: -pullToRefreshDefaultHeight)
-        let size = CGSize(width: self.frame.size.width, height: pullToRefreshDefaultHeight)
-        let frame = CGRect(origin: origin, size: size)
-        pullToRefreshView = PullToRefreshView(action: action, frame: frame)
-
-        addSubview(pullToRefreshView!)
-    }
-
-    public func addPullToRefresh(withAnimator animator: PullToRefreshDelegate & UIView,
-                                 height: CGFloat = pullToRefreshDefaultHeight,
-                                 action: @escaping (() -> ())) {
+    public func addPullToRefresh(height: CGFloat = 50,
+                                 contentView: (PullToRefreshDelegate & UIView)? = nil,
+                                 loadingBlock: @escaping (() -> ()))
+    {
         let frame = CGRect(x: 0, y: -height, width: self.frame.size.width, height: height)
-        pullToRefreshView = PullToRefreshView(action: action, frame: frame, animator: animator)
+        let pullToRefreshView = PullToRefreshView(frame: frame, contentView: contentView, loadingBlock: loadingBlock)
 
-        addSubview(pullToRefreshView!)
+        addSubview(pullToRefreshView)
+
+        self.pullToRefreshView = pullToRefreshView
     }
 
-    // Start pull to refresh
     public func startPullToRefresh() {
         pullToRefreshView?.isLoading = true
     }
 
-    // Stop pull to refresh
     public func stopPullToRefresh() {
         pullToRefreshView?.isLoading = false
     }
@@ -71,10 +60,13 @@ public extension UIScrollView {
     }
 
     // Add load more view with default animator
-    public func addLoadMore(action: @escaping (() -> ())) {
-        let size = CGSize(width: self.frame.size.width, height: loadMoreDefaultHeight)
+    public func addLoadMore(height: CGFloat = 50,
+                            contentView: (LoadMoreDelegate & UIView)? = nil,
+                            loadingBlock: @escaping (() -> ()))
+    {
+        let size = CGSize(width: self.frame.size.width, height: height)
         let frame = CGRect(origin: .zero, size: size)
-        loadMoreView = LoadMoreView(action: action, frame: frame)
+        loadMoreView = LoadMoreView(frame: frame, contentView: contentView, loadingBlock: loadingBlock)
         loadMoreView?.autoresizingMask = [.flexibleWidth, .flexibleHeight]
 
         addSubview(loadMoreView!)

--- a/Source/UIScrollView+Extensions.swift
+++ b/Source/UIScrollView+Extensions.swift
@@ -36,6 +36,10 @@ public extension UIScrollView {
         self.pullToRefreshView = pullToRefreshView
     }
 
+    public func removePullToRefresh() {
+        pullToRefreshView = nil
+    }
+
     public func startPullToRefresh() {
         pullToRefreshView?.isLoading = true
     }
@@ -66,10 +70,16 @@ public extension UIScrollView {
     {
         let size = CGSize(width: self.frame.size.width, height: height)
         let frame = CGRect(origin: .zero, size: size)
-        loadMoreView = LoadMoreView(frame: frame, contentView: contentView, loadingBlock: loadingBlock)
-        loadMoreView?.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        let loadMoreView = LoadMoreView(frame: frame, contentView: contentView, loadingBlock: loadingBlock)
+        loadMoreView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
 
-        addSubview(loadMoreView!)
+        addSubview(loadMoreView)
+
+        self.loadMoreView = loadMoreView
+    }
+
+    public func removeLoadMore() {
+        loadMoreView = nil
     }
 
     // Start load more


### PR DESCRIPTION
Firstly thanks for starting & sharing the project! I just started using it and made some changes including:

Make the states more clear, and reduce the delegate calls to just state change as the previous animationDidStart/Stop was actually the state changing to vs from loading

Use weak vars to hold delegates and scrollView to avoid retain cycles

Since we streamlined the state change and check against oldValue before calling the delegate, we avoid repeated delegate calls with the same state

Use default parameter values and ending closure syntax to reduce unnecessary initializers & param names.

Also corrected English grammars for the comments. Let me know what you think!